### PR TITLE
Sample upgrade to net6.0

### DIFF
--- a/Samples/DynamicODataSampleService/Controllers/TablesController.cs
+++ b/Samples/DynamicODataSampleService/Controllers/TablesController.cs
@@ -41,8 +41,8 @@ namespace DynamicODataSampleService.Controllers
             [FromQuery(Name = "$select")] string select,
             [FromQuery(Name = "$filter")] string filter,
             [FromQuery(Name = "$orderby")] string orderby,
-            [FromQuery(Name = "top")] int top = 10,
-            [FromQuery(Name = "skip")] int skip = 0)
+            [FromQuery(Name = "$top")] int top = 10,
+            [FromQuery(Name = "$skip")] int skip = 0)
         {
             var query = _oDataToSqlConverter.ConvertToSQL(tableName,
                     new Dictionary<string, string>

--- a/Samples/DynamicODataSampleService/Controllers/TablesController.cs
+++ b/Samples/DynamicODataSampleService/Controllers/TablesController.cs
@@ -38,11 +38,11 @@ namespace DynamicODataSampleService.Controllers
 
         [HttpGet("{tableName}", Name = "QueryRecords")]
         public async Task<IActionResult> QueryAsync(string tableName,
-            [FromQuery] string select,
-            [FromQuery] string filter,
-            [FromQuery] string orderby,
-            [FromQuery] int top = 10,
-            [FromQuery] int skip = 0)
+            [FromQuery(Name = "$select")] string select,
+            [FromQuery(Name = "$filter")] string filter,
+            [FromQuery(Name = "$orderby")] string orderby,
+            [FromQuery(Name = "top")] int top = 10,
+            [FromQuery(Name = "skip")] int skip = 0)
         {
             var query = _oDataToSqlConverter.ConvertToSQL(tableName,
                     new Dictionary<string, string>
@@ -55,22 +55,22 @@ namespace DynamicODataSampleService.Controllers
                     }
                 );
             IEnumerable<dynamic> rows = null;
-            using(var conn = new SqlConnection(_connectionString))
-            {
-                rows = await conn.QueryAsync(query.Item1, query.Item2).ConfigureAwait(false);                
-            }
+            await using var conn = new SqlConnection(this._connectionString);
+            rows = (await conn.QueryAsync(query.Item1, query.Item2).ConfigureAwait(false))?.ToList();
 
             ODataQueryResult result = null;
-            if (rows != null)
+            if (rows == null)
             {
-                var isLastPage = rows.Count() <= top;
-                result = new ODataQueryResult
-                {
-                    Count = isLastPage ? rows.Count() : rows.Count() - 1,
-                    Value = rows.Take(top),
-                    NextLink = isLastPage ? null : BuildNextLink(tableName, select, filter, orderby, top, skip)
-                };                    
+                return new JsonResult(result);
             }
+
+            var isLastPage = rows.Count() <= top;
+            result = new ODataQueryResult
+            {
+                Count = isLastPage ? rows.Count() : rows.Count() - 1,
+                Value = rows.Take(top),
+                NextLink = isLastPage ? null : this.BuildNextLink(tableName, @select, filter, @orderby, top, skip)
+            };
 
             return new JsonResult(result);
         }
@@ -87,7 +87,7 @@ namespace DynamicODataSampleService.Controllers
             nextLink = nextLink
                 .SetQueryParam("select", select)
                 .SetQueryParam("filter", filter)
-                .SetQueryParam("orderBy", orderby)                
+                .SetQueryParam("orderBy", orderby)
                 .SetQueryParam("top", top)
                 .SetQueryParam("skip", skip + top);
 

--- a/Samples/DynamicODataSampleService/DynamicODataSampleService.csproj
+++ b/Samples/DynamicODataSampleService/DynamicODataSampleService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>c12c2bb9-bfa1-43a1-bf2c-4d1963551e30</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
@@ -9,10 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.35" />
-    <PackageReference Include="DynamicODataToSQL" Version="1.0.2" />
+    <PackageReference Include="DynamicODataToSQL" Version="1.0.5" />
     <PackageReference Include="Flurl" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 


### PR DESCRIPTION
- Small changes to bump the sample project to net 6.0
- Query action now accepts the dollar sign version of the OData parameters (e.g. $filter, $select)