### PR TITLE
Enabling converting to SQL using custom SQL as a source

### DIFF
--- a/Source/DynamicODataToSQL/Interfaces/IODataToSqlConverter.cs
+++ b/Source/DynamicODataToSQL/Interfaces/IODataToSqlConverter.cs
@@ -19,5 +19,17 @@ namespace DynamicODataToSQL
             string tableName,
             IDictionary<string, string> odataQuery,
             bool count = false);
+
+        /// <summary>
+        /// ConvertToSQL.
+        /// </summary>
+        /// <param name="rawSql">rawSql.</param>
+        /// <param name="odataQuery">odataQuery.</param>
+        /// <param name="count">count.</param>
+        /// <returns>Tuple.</returns>
+        (string, IDictionary<string, object>) ConvertToSqlFromRawSql(
+            string rawSql,
+            IDictionary<string, string> odataQuery,
+            bool count = false);
     }
 }

--- a/Tests/DynamicODataToSQL.Test/ODataToSqlFromRawSqlConverterTests.cs
+++ b/Tests/DynamicODataToSQL.Test/ODataToSqlFromRawSqlConverterTests.cs
@@ -1,0 +1,270 @@
+namespace DynamicODataToSQL.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using SqlKata.Compilers;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ODataToSqlFromRawSqlConverterTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public ODataToSqlFromRawSqlConverterTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+
+        [Theory]
+        [MemberData(nameof(GetTestData))]
+        public void ConvertToSQLFromRawSql_ExpectedBehavior(
+            string testName,
+            string rawSql,
+            IDictionary<string,string> odataQuery,
+            bool count,
+            string expectedSQL,
+            IDictionary<string,object> expectedSQLParams)
+        {
+            // Arrange
+            var oDataToSqlConverter = CreateODataToSqlConverter();
+
+            // Act
+            output.WriteLine($"Test: {testName}");
+            output.WriteLine($"ODataQuery : {string.Join("&",odataQuery.Select(kvp => $"{kvp.Key}={kvp.Value}"))}");
+            output.WriteLine("Expected SQL: \n{0} \nParams: {1}", expectedSQL, string.Join(",", expectedSQLParams.ToArray().Select(kvp => $"{kvp.Key}={kvp.Value}")));
+            var result = oDataToSqlConverter.ConvertToSqlFromRawSql(
+                rawSql,
+                odataQuery,
+                count);
+
+            // Assert
+            var actualSQL = result.Item1;
+            var actualSQLParams = result.Item2;            
+            output.WriteLine("Actual SQL: \n{0} \nParams: {1}", actualSQL, string.Join(",", actualSQLParams.ToArray().Select(kvp => $"{kvp.Key}={kvp.Value}")));
+
+            Assert.Equal(expectedSQL, actualSQL, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);            
+            Assert.Equal(expectedSQLParams, actualSQLParams);
+        }
+
+        public static IEnumerable<object[]> GetTestData()
+        {           
+
+            // Test 1 
+            {
+                var testName = "Select+Filter+Sort+Pagination";
+                var rawSql = "SELECT * FROM [Products]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"select", "Name, Type" },
+                    {"filter", "contains(Name,'Tea')" },
+                    {"orderby", "Id desc" },
+                    {"top", "20" },
+                    {"skip", "5" },
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Products])\nSELECT [Name], [Type] FROM [RawSql] WHERE [Name] like @p0 ORDER BY [Id] DESC OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY";
+                var expectedSQLParams = new Dictionary<string, object>
+                {                    
+                    {"@p0", "%Tea%"},
+                    {"@p1", 5},
+                    {"@p2", 20},
+                };
+                yield return new object[] { testName, rawSql, odataQueryParams,false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 2 
+            {
+                var testName = "Select+Sort+Pagination";
+                var rawSql = "SELECT * FROM [Products]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"select", "Name, Type" },
+                    {"orderby", "Id desc" },
+                    {"top", "20" },
+                    {"skip", "5"},
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Products])\nSELECT [Name], [Type] FROM [RawSql] ORDER BY [Id] DESC OFFSET @p0 ROWS FETCH NEXT @p1 ROWS ONLY";
+                var expectedSQLParams = new Dictionary<string, object>
+                {
+                    {"@p0", 5 },                   
+                    {"@p1", 20},                    
+                };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 3
+            {
+                var testName = "SelectAll+Filter+Sort+Pagination";
+                var rawSql = "SELECT * FROM [Products]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"filter", "contains(Name,'Tea')" },
+                    {"orderby", "Id desc" },
+                    {"top", "20" },
+                    {"skip", "0" },
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Products])\nSELECT * FROM [RawSql] WHERE [Name] like @p0 ORDER BY [Id] DESC OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY";
+                var expectedSQLParams = new Dictionary<string, object>
+                {                    
+                    {"@p0", "%Tea%"},
+                    {"@p1", 0 },
+                    {"@p2", 20 },
+                };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 4
+            {
+                var testName = "Select+Filter";
+                var rawSql = "SELECT * FROM [Products]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"select", "Name, Type" },
+                    {"filter", "contains(Name,'Tea')" },
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Products])\nSELECT [Name], [Type] FROM [RawSql] WHERE [Name] like @p0";
+                var expectedSQLParams = new Dictionary<string, object>
+                {                    
+                    {"@p0", "%Tea%"}
+                };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+
+            // Test 5
+            {
+                var testName = "AdvancedFilters";
+                var rawSql = "SELECT * FROM [Products]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"filter", "contains(Name,'Tea') or (TotalInventory ge 100 and TotalInventory le 1000) or (TimeCreated gt '2020-06-01T00:00-04:00' and TimeCreated lt '2020-07-01T00:00-04:00') or not (Origin eq 'Canada' or Origin eq 'USA')" },
+                    {"orderby", "Id desc" }
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Products])\nSELECT * FROM [RawSql] WHERE ((([Name] like @p0 OR ([TotalInventory] >= @p1 AND [TotalInventory] <= @p2)) OR ([TimeCreated] > @p3 AND [TimeCreated] < @p4)) OR NOT ([Origin] = @p5 OR [Origin] = @p6)) ORDER BY [Id] DESC";
+                var expectedSQLParams = new Dictionary<string, object>
+                {                   
+                    {"@p0", "%Tea%"},
+                    {"@p1", 100},
+                    {"@p2", 1000},
+                    {"@p3", new DateTime(2020,6,1,4,0,0,DateTimeKind.Utc)},
+                    {"@p4", new DateTime(2020,7,1,4,0,0,DateTimeKind.Utc)},
+                    {"@p5", "Canada"},
+                    {"@p6", "USA"},
+                };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+
+            // Test 6
+            {
+                var testName = "Aggregate";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"apply","aggregate(TotalAmount with sum as TotalAmount, TotalAmount with average as AverageAmount,$count as OrderCount)"}
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT SUM(TotalAmount) AS TotalAmount, AVG(TotalAmount) AS AverageAmount, Count(1) AS OrderCount FROM [RawSql]";
+                var expectedSQLParams = new Dictionary<string, object> { };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+            
+
+            // Test 7
+            {
+                var testName = "GroupBy";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"apply","groupby((Country),aggregate(Amount with sum as Total,Amount with average as AvgAmt))"}
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT [Country], Sum(Amount) AS Total, Avg(Amount) AS AvgAmt FROM [RawSql] GROUP BY [Country]";
+                var expectedSQLParams = new Dictionary<string, object> { };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+
+            // Test 9
+            {
+                var testName = "Filter+GroupBy";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"apply","filter(Amount ge 100)/groupby((Country),aggregate(Amount with sum as Total,Amount with average as AvgAmt))"}
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT [Country], Sum(Amount) AS Total, AVG(Amount) AS AvgAmt FROM [RawSql] WHERE [Amount] >= @p0 GROUP BY [Country]";
+                var expectedSQLParams = new Dictionary<string, object> { {"@p0", 100} };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 10
+            {
+                var testName = "Filter+GroupBy+Filter";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"apply","filter(Amount ge 100)/groupby((Country),aggregate(Amount with sum as Total,Amount with average as AvgAmt))/filter(AvgAmt ge 20)"}
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT * FROM (SELECT [Country], Sum(Amount) AS Total, AVG(Amount) AS AvgAmt FROM [RawSql] WHERE [Amount] >= @p0 GROUP BY [Country]) WHERE [AvgAmt] >= @p1";
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 100 },{"@p1",20 } };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 11
+            {
+                var testName = "Filter+GroupBy++Filter";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"apply","filter(Amount ge 100)/groupby((Country),aggregate(Amount with sum as Total,Amount with average as AvgAmt))"},
+                    {"filter","AvgAmt ge 20" }
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT * FROM (SELECT [Country], Sum(Amount) AS Total, AVG(Amount) AS AvgAmt FROM [RawSql] WHERE [Amount] >= @p0 GROUP BY [Country]) AS [apply] WHERE [AvgAmt] >= @p1";
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 100 }, { "@p1", 20 } };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 12
+            {
+                var testName = "DateTimeFunctions";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {                    
+                    {"filter","year(OrderDate) eq 1971" }
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT * FROM [RawSql] WHERE DATEPART(YEAR, [OrderDate]) = @p0";
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 1971 }};
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 13
+            {
+                var testName = "DateTimeFunctions-Date";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"filter","date(OrderDate) gt '2001-01-17'" }
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT * FROM [RawSql] WHERE CAST([OrderDate] as date) > @p0";
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", "2001-01-17" } };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+            // Test 14
+            {
+                var testName = "DateTimeFunctions-Time";
+                var rawSql = "SELECT * FROM [Orders]";
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"filter","time(OrderDate) gt '16:30'" }
+                };
+                var expectedSQL = "WITH [RawSql] AS (SELECT * FROM [Orders])\nSELECT * FROM [RawSql] WHERE CAST([OrderDate] as time) > @p0";
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", "16:30" } };
+                yield return new object[] { testName, rawSql, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
+
+        }
+
+        private static ODataToSqlConverter CreateODataToSqlConverter() => new ODataToSqlConverter(new EdmModelBuilder(), new SqlServerCompiler() { UseLegacyPagination = false });
+    }
+}


### PR DESCRIPTION
Enabling converting to SQL using custom SQL as a source (instead of a table)

I have a scenario in which I need to use an existing SQL query as the source of the oData controller. By adding the **ConvertToSqlFromRawSql** method I'm able to use ODataToSqlConverter functionality on top of my custom query.

I added separate tests based on the existing ones, that instead of a table use simple select. 

If anything should be changed/fixed I'm open to doing it so. Thank you! 