### PR TITLE
feat: support spaces in columns via replacement sign

### DIFF
--- a/Source/DynamicODataToSQL/ApplyClauseBuilder.cs
+++ b/Source/DynamicODataToSQL/ApplyClauseBuilder.cs
@@ -190,8 +190,11 @@ namespace DynamicODataToSQL
                 column = (node as SingleValueOpenPropertyAccessNode).Name.Trim();
             }
             if (wrap)
-                return this._compiler.WrapValue(column);
-            return column;
+            {
+                return this._compiler.WrapValue(column).Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " ");
+            }
+                
+            return column.Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " ");
         }
     }
 }

--- a/Source/DynamicODataToSQL/FilterClauseBuilder.cs
+++ b/Source/DynamicODataToSQL/FilterClauseBuilder.cs
@@ -249,7 +249,7 @@ namespace DynamicODataToSQL
                 column = (node as SingleValueOpenPropertyAccessNode).Name.Trim();
             }
 
-            return column;
+            return column.Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " ");
         }
 
         private object GetConstantValue(QueryNode node)

--- a/Source/DynamicODataToSQL/ODataToSqlConverter.cs
+++ b/Source/DynamicODataToSQL/ODataToSqlConverter.cs
@@ -12,6 +12,8 @@ namespace DynamicODataToSQL
     /// <inheritdoc/>
     public class ODataToSqlConverter : IODataToSqlConverter
     {
+        public const string SPACE_SIGN_REPLACEMENT = "_x0020_";
+
         private readonly IEdmModelBuilder _edmModelBuilder;
         private readonly Compiler _sqlCompiler;
 
@@ -178,11 +180,11 @@ namespace DynamicODataToSQL
                 {
                     if (direction == OrderByDirection.Ascending)
                     {
-                        query = query.OrderBy(expression.Name.Trim());
+                        query = query.OrderBy(expression.Name.Trim().Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " "));
                     }
                     else
                     {
-                        query = query.OrderByDesc(expression.Name.Trim());
+                        query = query.OrderByDesc(expression.Name.Trim().Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " "));
                     }
                 }
 
@@ -200,7 +202,7 @@ namespace DynamicODataToSQL
                 {
                     if (selectItem is PathSelectItem path)
                     {
-                        query = query.Select(path.SelectedPath.FirstSegment.Identifier.Trim());
+                        query = query.Select(path.SelectedPath.FirstSegment.Identifier.Trim().Replace(SPACE_SIGN_REPLACEMENT, " "));
                     }
                 }
             }

--- a/Tests/DynamicODataToSQL.Test/ODataToSqlConverterTests.cs
+++ b/Tests/DynamicODataToSQL.Test/ODataToSqlConverterTests.cs
@@ -73,7 +73,7 @@ namespace DynamicODataToSQL.Test
                     {"@p1", 5},
                     {"@p2", 20},
                 };
-                yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams,false, expectedSQL, expectedSQLParams };
+                yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
 
             // Test 2
@@ -203,7 +203,7 @@ namespace DynamicODataToSQL.Test
                     {"apply","filter(Amount ge 100)/groupby((Country),aggregate(Amount with sum as Total,Amount with average as AvgAmt))"}
                 };
                 var expectedSQL = @"SELECT [Country], Sum([Amount]) AS [Total], AVG([Amount]) AS [AvgAmt] FROM [Orders] WHERE [Amount] >= @p0 GROUP BY [Country]";
-                var expectedSQLParams = new Dictionary<string, object> { {"@p0", 100} };
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 100 } };
                 yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
 
@@ -217,7 +217,7 @@ namespace DynamicODataToSQL.Test
                     {"apply","filter(Amount ge 100)/groupby((Country),aggregate(Amount with sum as Total,Amount with average as AvgAmt))/filter(AvgAmt ge 20)"}
                 };
                 var expectedSQL = @"SELECT * FROM (SELECT [Country], Sum([Amount]) AS [Total], AVG([Amount]) AS [AvgAmt] FROM [Orders] WHERE [Amount] >= @p0 GROUP BY [Country]) WHERE [AvgAmt] >= @p1";
-                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 100 },{"@p1",20 } };
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 100 }, { "@p1", 20 } };
                 yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
 
@@ -246,7 +246,7 @@ namespace DynamicODataToSQL.Test
                     {"filter","year(OrderDate) eq 1971" }
                 };
                 var expectedSQL = @"SELECT * FROM [Orders] WHERE DATEPART(YEAR, [OrderDate]) = @p0";
-                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 1971 }};
+                var expectedSQLParams = new Dictionary<string, object> { { "@p0", 1971 } };
                 yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
 
@@ -322,7 +322,7 @@ namespace DynamicODataToSQL.Test
                     {"apply","compute(year(OrderDate) as yr, month(OrderDate) as mn)/groupby((yr,mn),aggregate(value with average as AvgValue))" }
                 };
                 var expectedSQL = @"SELECT [yr], [mn], AVG([value]) AS [AvgValue] FROM (SELECT *, year(OrderDate) as yr, month(OrderDate) as mn FROM [Orders]) GROUP BY [yr], [mn]";
-                var expectedSQLParams = new Dictionary<string, object> {  };
+                var expectedSQLParams = new Dictionary<string, object> { };
                 yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
 
@@ -394,7 +394,28 @@ namespace DynamicODataToSQL.Test
                 };
                 yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
-
+            // Test 20
+            {
+                var testName = "Select+ColumnsWithSpaces";
+                var tableName = "Products";
+                var tryToParseDates = true;
+                var odataQueryParams = new Dictionary<string, string>
+                {
+                    {"select", "Name, Type, Spaced_x0020_Column" },
+                    {"filter", "contains(Spaced_x0020_Column,'Tea')" },
+                    {"orderby", "Spaced_x0020_Column desc" },
+                    {"top", "20" },
+                    {"skip", "5" },
+                };
+                var expectedSQL = @"SELECT [Name], [Type], [Spaced Column] FROM [Products] WHERE [Spaced Column] like @p0 ORDER BY [Spaced Column] DESC OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY";
+                var expectedSQLParams = new Dictionary<string, object>
+                {
+                    {"@p0", "%Tea%"},
+                    {"@p1", 5},
+                    {"@p2", 20},
+                };
+                yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
+            }
         }
 
         private static ODataToSqlConverter CreateODataToSqlConverter() => new ODataToSqlConverter(new EdmModelBuilder(), new SqlServerCompiler() { UseLegacyPagination = false });


### PR DESCRIPTION
This could perhaps be an alternative to supporting single quotes for column names with spaces. It follows the same idea as Sharepoint's OData Conventions (https://learn.microsoft.com/en-us/sharepoint/dev/business-apps/power-automate/guidance/working-with-get-items-and-get-files#order-by-query) by expecting `_x0020_` instead of spaces. So column [Spaced Column] should be sent like `Spaced_x0020_Column`.

MS themselves leaning on this sounds like there is no generic solution the OData protocol itself promotes.

EDIT: btw I do realize I didn't yet add docs or extended the example. I first wanted to check back whether this approach is worth pursuing.

Potential workaround for #14 