### PR TITLE
Support 'in' logical operator

### DIFF
--- a/Source/DynamicODataToSQL/EdmModelBuilder.cs
+++ b/Source/DynamicODataToSQL/EdmModelBuilder.cs
@@ -19,6 +19,7 @@ namespace DynamicODataToSQL
 
             var model = new EdmModel();
             var entityType = new EdmEntityType(DEFAULTNAMESPACE, tableName, null, false, true);
+            AddProperties(entityType);
             model.AddElement(entityType);
 
             var defaultContainer = new EdmEntityContainer(DEFAULTNAMESPACE, "DefaultContainer");
@@ -26,6 +27,10 @@ namespace DynamicODataToSQL
             var entitySet = defaultContainer.AddEntitySet(tableName, entityType);
 
             return (model, entityType, entitySet);
+        }
+
+        protected virtual void AddProperties(EdmEntityType entityType)
+        {
         }
     }
 }

--- a/Source/DynamicODataToSQL/ODataToSqlConverter.cs
+++ b/Source/DynamicODataToSQL/ODataToSqlConverter.cs
@@ -176,15 +176,16 @@ namespace DynamicODataToSQL
             while (orderbyClause != null)
             {
                 var direction = orderbyClause.Direction;
-                if (orderbyClause.Expression is SingleValueOpenPropertyAccessNode expression)
+                var expressionName = GetSingleValuePropertyAccessNodeName(orderbyClause.Expression);
+                if (expressionName is not null)
                 {
                     if (direction == OrderByDirection.Ascending)
                     {
-                        query = query.OrderBy(expression.Name.Trim().Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " "));
+                        query = query.OrderBy(expressionName.Trim().Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " "));
                     }
                     else
                     {
-                        query = query.OrderByDesc(expression.Name.Trim().Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " "));
+                        query = query.OrderByDesc(expressionName.Trim().Replace(ODataToSqlConverter.SPACE_SIGN_REPLACEMENT, " "));
                     }
                 }
 
@@ -192,6 +193,21 @@ namespace DynamicODataToSQL
             }
 
             return query;
+        }
+
+        private static string GetSingleValuePropertyAccessNodeName(SingleValueNode expression)
+        {
+            if (expression is SingleValueOpenPropertyAccessNode openProperty)
+            {
+                return openProperty.Name;
+            }
+
+            if (expression is SingleValuePropertyAccessNode property)
+            {
+                return property.Property.Name;
+            }
+
+            return null;
         }
 
         private static Query BuildSelectClause(Query query, SelectExpandClause selectClause)

--- a/Tests/DynamicODataToSQL.Test/TestsEdmModelBuilder.cs
+++ b/Tests/DynamicODataToSQL.Test/TestsEdmModelBuilder.cs
@@ -1,0 +1,53 @@
+﻿namespace DynamicODataToSQL
+{
+    using System.Collections.Generic;
+    using Microsoft.OData.Edm;
+
+    /// <inheritdoc/>
+    /// <summary>
+    /// EdmModelBuilder with known test tables properties.
+    /// </summary>
+    public class TestsEdmModelBuilder : EdmModelBuilder
+    {
+        private readonly Dictionary<string, Dictionary<string, EdmPrimitiveTypeKind>> _knownTableProperties;
+
+        public TestsEdmModelBuilder()
+        {
+            _knownTableProperties = new Dictionary<string, Dictionary<string, EdmPrimitiveTypeKind>>
+            {
+                ["Products"] = new Dictionary<string, EdmPrimitiveTypeKind>
+                {
+                    ["Id"] = EdmPrimitiveTypeKind.Int32,
+                    ["Name"] = EdmPrimitiveTypeKind.String,
+                    ["Type"] = EdmPrimitiveTypeKind.String,
+                    ["TotalInventory"] = EdmPrimitiveTypeKind.Int32,
+                    ["TimeCreated"] = EdmPrimitiveTypeKind.DateTimeOffset,
+                    ["Origin"] = EdmPrimitiveTypeKind.String,
+                    ["Spaced Column"] = EdmPrimitiveTypeKind.String
+                },
+                ["Orders"] = new Dictionary<string, EdmPrimitiveTypeKind>
+                {
+                    ["OrderId"] = EdmPrimitiveTypeKind.Int32,
+                    ["TotalAmount"] = EdmPrimitiveTypeKind.Double,
+                    ["Country"] = EdmPrimitiveTypeKind.String,
+                    ["Amount"] = EdmPrimitiveTypeKind.Double,
+                    ["OrderDate"] = EdmPrimitiveTypeKind.DateTimeOffset,
+                    ["value"] = EdmPrimitiveTypeKind.Double
+                }
+            };
+        }
+
+        protected override void AddProperties(EdmEntityType entityType)
+        {
+            var tableName = entityType.Name;
+
+            if (_knownTableProperties.TryGetValue(tableName, out Dictionary<string, EdmPrimitiveTypeKind>? value))
+            {
+                foreach (var column in value)
+                {
+                    entityType.AddStructuralProperty(column.Key, column.Value);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #32 

This adds support for the 'in' logical operator in $filter clauses.

When attempting to use 'in' to filter data types other than string, specifying column data types in the EdmModelBuilder is required. Otherwise, `Microsoft.OData.ODataException` will be thrown. For instance, trying to filter on integers without specifying the column's datatype in EdmModelBuilder will throw `Microsoft.OData.ODataException : String item should be single/double quoted`.

Because of that, I also added a new method to `EdmModelBuilder` that can be overloaded to specify the columns' structural properties. Some side effects of specifying column data types are:
- Filter values can no longer all be specified as strings. Tests involving date filters, for instance, had quotation marks removed because of that.
- Expected parameter values in tests can no longer be compared as strings, but by their actual data types instead.

This ended up needing a bit more work than I first intended, but it seems to work fine. Please let me know of any concerns.