### PR TITLE
feat: support for matchespattern

### DIFF
--- a/Source/DynamicODataToSQL/FilterClauseBuilder.cs
+++ b/Source/DynamicODataToSQL/FilterClauseBuilder.cs
@@ -136,6 +136,22 @@ namespace DynamicODataToSQL
                 case "startswith":
                     return _query.WhereStarts(columnName, (string)GetConstantValue(nodes[1]), caseSensitive);
 
+                case "matchespattern":
+                    var value = ((string)this.GetConstantValue(nodes[1]))
+                        .Replace(".*", "%");
+
+                    if (value.StartsWith("%5E", StringComparison.InvariantCulture))
+                    {
+                        value = value.Replace("%5E", "");
+                    }
+
+                    if (value[value.Length - 1] == '$')
+                    {
+                        value = value.Substring(0, value.Length - 1);
+                    }
+                    
+                    return _query.WhereLike(columnName, value, caseSensitive);
+
                 default:
                     return _query;
             }

--- a/Tests/DynamicODataToSQL.Test/ODataToSqlConverterTests.cs
+++ b/Tests/DynamicODataToSQL.Test/ODataToSqlConverterTests.cs
@@ -417,7 +417,30 @@ namespace DynamicODataToSQL.Test
                 };
                 yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
             }
-        }
+            // Test 21
+            {
+				var testName = "Filter+matchesPattern";
+				var tableName = "Products";
+				var tryToParseDates = true;
+				var pattern = ".*ello.*rld";
+				var odataQueryParams = new Dictionary<string, string>
+				{
+					{"select", "Name, Type" },
+					{"filter", $"matchesPattern(Name,'%5E{pattern}$')" },
+					{"orderby", "Name desc" },
+					{"top", "20" },
+					{"skip", "5" },
+				};
+				var expectedSQL = @"SELECT [Name], [Type] FROM [Products] WHERE [Name] like @p0 ORDER BY [Name] DESC OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY";
+				var expectedSQLParams = new Dictionary<string, object>
+				{
+					{"@p0", $"{pattern.Replace(".*", "%")}"},
+					{"@p1", (long)5},
+					{"@p2", 20},
+				};
+				yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
+			}
+		}
 
         private static ODataToSqlConverter CreateODataToSqlConverter() => new ODataToSqlConverter(new EdmModelBuilder(), new SqlServerCompiler() { UseLegacyPagination = false });
     }


### PR DESCRIPTION
this converts the provided EcmaScript Regex to LIKE statements.
On top of that it translates `.*` to `%` resulting in the option to have proper multi wildcard usages.
